### PR TITLE
Docker authorization for both aws cli versions

### DIFF
--- a/d2_custom_sku110k.ipynb
+++ b/d2_custom_sku110k.ipynb
@@ -508,9 +508,9 @@
     "REGION=YOUR_REGION\n",
     "ACCOUNT=YOUR_ACCOUNT_ID\n",
     "\n",
-    "aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin 763104351884.dkr.ecr.$REGION.amazonaws.com\n",
+    "aws ecr get-login --registry-ids 763104351884 --no-include-email --region $REGION | cut -d " " -f 6  | docker login --username AWS --password-stdin 763104351884.dkr.ecr.$REGION.amazonaws.com\n",
     "# loging to your private ECR\n",
-    "aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.$REGION.amazonaws.com"
+    "aws ecr get-login --registry-ids ACCOUNT --no-include-email --region $REGION | cut -d " " -f 6  | docker login --username AWS --password-stdin $ACCOUNT.dkr.ecr.$REGION.amazonaws.com"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
Docker authorization part was not working with aws cli version 1 which is default when creating notebooks.

*Description of changes:*
Docker authorization part in the notebook d2_custom_sku110k.ipynb will workfor  both aws cli versions now!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
